### PR TITLE
Enable raw JSON query logging and mounting logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,17 @@ COPY ./ /srv/app
 WORKDIR /srv/app
 
 RUN mkdir -p /srv/app/endpoints
+RUN mkdir -p /srv/app/logs
 
 ARG ELASTICSEARCH_HOST
 ARG INDEX_ROTATION
+ARG LOG_EVENTS
 
 RUN rm -rf node_modules
 RUN npm install --production
 
 VOLUME /srv/app/endpoints
+VOLUME /srv/app/logs
 
 EXPOSE 3000
 ENTRYPOINT npm start

--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ const getIndexName = () => {
 		case 'OneMonth':
 			return `${ indexBase }-${ format( date, 'yyyy-MM' ) }`;
 		case 'OneWeek':
-			return `${ indexBase }-${ format( date, 'yyyy-ww' ) }`;
+			return `${ indexBase }-${ format( date, 'yyyy-\'w\'ww' ) }`;
 		case 'OneDay':
 			return `${ indexBase }-${ format( date, 'yyyy-MM-dd' ) }`;
 		case 'OneHour':


### PR DESCRIPTION
This addition allows users to specify an environment variable `LOG_EVENTS` that causes all JSON data being to sent to elasticsearch to be recorded to a log file.

The log file itself can be mounted using volumes (if using docker via `--volume=logs/pinpoint:/srv/app/logs`) or in the app directory if running using node directly.